### PR TITLE
chore(codeowners): add and init codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Codeowners file for transcendence
+# People defined as owners of some code matching a pattern
+# This can be used to automatically request reviews from the codeowners
+# Multiple codeowners do not share authority, each codeowner has full authority independently
+# Later matches override earlier ones
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global and default codeowners
+* @mxafi @Hunam6 @Rubidium7 @Markfelixm
+
+# Protect codeowners file
+/.github/CODEOWNERS @mxafi


### PR DESCRIPTION
**What it does currently:**

- Enables requiring a review from a code owner before merging pull request (not enabled yet)
- Defines the team members as codeowners for every file in the repo (every team member owns every file)
- Defines me as the owner of the codeowners file, overriding the earlier definition. That way, no changes to it can be made without at least my approval, when the review requirement goes into effect.

**What can it do later:**
- Define individual team members to be responsible for reviewing changes for specific files (e.g. Mark for frontend files etc.)
