### PR TITLE
fix(devcontainer): mv .env stuff to init-host.sh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,8 @@
 			]
 		}
 	},
+	// run commands on the host before the container is created
+	"initializeCommand": "bash ${localWorkspaceFolder}/.devcontainer/init-host.sh ${localWorkspaceFolder}",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/init-host.sh
+++ b/.devcontainer/init-host.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script runs in the context of the host machine when the container is created.
+# It is used to perform tasks that are not possible from within the container, or are requirements for the container to run.
+# The first parameter passed to the script is the path to the root of the project.
+
+SCRIPT_NAME=$0
+PROJECT_ROOT=$1
+
+function check_if_project_root_exists() {
+  if [ -z "$PROJECT_ROOT" ]; then
+    echo "$SCRIPT_NAME: PROJECT_ROOT variable is empty. Please provide the path to the root of the project (in devcontainer) as the first argument."
+    exit 1
+  fi
+  if [ ! -d "$PROJECT_ROOT" ]; then
+    echo "$SCRIPT_NAME: Project root does not exist. Please provide the correct path to the root of the project (in devcontainer) as the first argument."
+    exit 1
+  fi
+}
+
+function copy_env_file_if_not_exists() {
+  if [ ! -f .env ]; then
+    cp .env.example .env
+  fi
+}
+
+main() {
+    check_if_project_root_exists
+    copy_env_file_if_not_exists
+}
+
+main

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -18,12 +18,6 @@ function check_if_project_root_exists() {
   fi
 }
 
-function copy_env_file_if_not_exists() {
-  if [ ! -f .env ]; then
-    cp .env.example .env
-  fi
-}
-
 function install_python_requirements() {
   pip install --user -r requirements.txt
 }
@@ -48,7 +42,6 @@ function compile_translation_files() {
 function main() {
   check_if_project_root_exists
   cd $PROJECT_ROOT
-  copy_env_file_if_not_exists
   source .env
   install_python_requirements
   migrate_database


### PR DESCRIPTION
.env has to be created before calling docker-compose

This is critical to make devcontainers work without having a .env file already existing