### PR TITLE
fix(join): check that local players don't have the same name

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -49,6 +49,11 @@ def join(request: HttpRequest):
             "Player 2 name must be between 1 and 12 characters"
         )
 
+    if (fields["player-1-name"] == fields["player-2-name"]):
+        return HttpResponseBadRequest(
+            "Players 1 and 2 can't have the same name"
+        )
+
     is_tournament = False
     is_match_four = False
     player_count = -1


### PR DESCRIPTION
Local players could have the same name which resulted in both controls working for only one side