### PR TITLE
Fix lobby delete

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -17,7 +17,7 @@ class Player(models.Model):
     lobby = models.ForeignKey(Lobby, on_delete=models.CASCADE, related_name="players")
     name = models.CharField(max_length=12)
     channel_name = models.CharField(max_length=100, null=True)
-    is_disconnected = models.BooleanField(default=False)
+    is_disconnected = models.BooleanField(default=True)
     is_eliminated = models.BooleanField(default=False)
     is_ai = models.BooleanField(default=False)
 


### PR DESCRIPTION
now:
- cancels of the task when the lobby is empty. 
- removes the channel from the channel_to_lobby when last player disconnects
- removes lobby from lobby_to_gs when game ends
- has some added checks for edge cases caused by abrupt player disconnects